### PR TITLE
Adds pausability to transfer requests.

### DIFF
--- a/evm/forge-test/CircleRelayerGovernance.t.sol
+++ b/evm/forge-test/CircleRelayerGovernance.t.sol
@@ -59,10 +59,7 @@ contract CircleRelayerGovernanceTest is Test, ForgeHelpers {
     function setupUSDC() public {
         usdc = IUSDC(vm.envAddress("TESTING_USDC_TOKEN_ADDRESS"));
 
-        (, bytes memory queriedDecimals) = address(usdc).staticcall(
-            abi.encodeWithSignature("decimals()")
-        );
-        uint8 decimals = abi.decode(queriedDecimals, (uint8));
+        uint8 decimals = usdc.decimals();
         require(decimals == 6, "wrong USDC");
 
         // spoof .configureMinter() call with the master minter account

--- a/evm/forge-test/CircleRelayerGovernance.t.sol
+++ b/evm/forge-test/CircleRelayerGovernance.t.sol
@@ -84,13 +84,14 @@ contract CircleRelayerGovernanceTest is Test, ForgeHelpers {
         relayer = ICircleRelayer(address(deployedRelayer));
 
         // verify initial state
-        assertEq(relayer.chainId(), wormhole.chainId());
-        assertEq(address(relayer.wormhole()), address(wormhole));
+        assertEq(relayer.chainId(), wormhole.chainId(), "Wrong circle relayer chain id");
+        assertEq(address(relayer.wormhole()), address(wormhole), "Wrong wormhole core address");
         assertEq(
             address(relayer.circleIntegration()),
-            vm.envAddress("TESTING_CIRCLE_INTEGRATION_ADDRESS")
+            vm.envAddress("TESTING_CIRCLE_INTEGRATION_ADDRESS"),
+            "Wrong circle integration address"
         );
-        assertEq(relayer.nativeSwapRatePrecision(), 1e8);
+        assertEq(relayer.nativeSwapRatePrecision(), 1e8, "Wrong native swap rate precision");
     }
 
     function setUp() public {

--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -2,6 +2,7 @@
 solc_version = "0.8.17"
 optimizer = true
 optimizer_runs = 200
+via_ir = true
 
 test = "forge-test"
 

--- a/evm/src/circle-relayer/CircleRelayer.sol
+++ b/evm/src/circle-relayer/CircleRelayer.sol
@@ -19,6 +19,22 @@ import "./CircleRelayerMessages.sol";
 contract CircleRelayer is CircleRelayerMessages, CircleRelayerGovernance, ReentrancyGuard {
     using BytesLib for bytes;
 
+    /**
+     * @notice Emitted when a swap is executed with an off-chain relayer
+     * @param recipient Address of the recipient of the native assets
+     * @param relayer Address of the relayer that performed the swap
+     * @param token Address of the token being swapped
+     * @param tokenAmount Amount of token being swapped
+     * @param nativeAmount Amount of native assets swapped for tokens
+     */
+    event SwapExecuted(
+        address indexed recipient,
+        address indexed relayer,
+        address indexed token,
+        uint256 tokenAmount,
+        uint256 nativeAmount
+    );
+
     constructor(
         address circleIntegration_,
         uint8 nativeTokenDecimals_
@@ -207,6 +223,15 @@ contract CircleRelayer is CircleRelayerMessages, CircleRelayerGovernance, Reentr
 
                 // send requested native asset to target recipient
                 payable(recipient).transfer(nativeAmountForRecipient);
+
+                // emit swap event
+                emit SwapExecuted(
+                    recipient,
+                    msg.sender,
+                    address(token),
+                    transferMessage.toNativeTokenAmount,
+                    nativeAmountForRecipient
+                );
             } else {
                 // override the toNativeTokenAmount in the transferMessage
                 transferMessage.toNativeTokenAmount = 0;

--- a/evm/src/circle-relayer/CircleRelayer.sol
+++ b/evm/src/circle-relayer/CircleRelayer.sol
@@ -22,7 +22,7 @@ contract CircleRelayer is CircleRelayerMessages, CircleRelayerGovernance, Reentr
     constructor(
         address circleIntegration_,
         uint8 nativeTokenDecimals_
-    ) public {
+    ) {
         require(circleIntegration_ != address(0), "invalid circle integration address");
         require(nativeTokenDecimals_ > 0, "invalid native decimals");
 

--- a/evm/src/circle-relayer/CircleRelayer.sol
+++ b/evm/src/circle-relayer/CircleRelayer.sol
@@ -75,7 +75,7 @@ contract CircleRelayer is CircleRelayerMessages, CircleRelayerGovernance, Reentr
         uint256 toNativeTokenAmount,
         uint16 targetChain,
         bytes32 targetRecipientWallet
-    ) public payable nonReentrant returns (uint64 messageSequence) {
+    ) public payable nonReentrant notPaused returns (uint64 messageSequence) {
         // sanity check input values
         require(amount > 0, "amount must be > 0");
         require(targetRecipientWallet != bytes32(0), "invalid target recipient");

--- a/evm/src/circle-relayer/CircleRelayer.sol
+++ b/evm/src/circle-relayer/CircleRelayer.sol
@@ -276,8 +276,7 @@ contract CircleRelayer is CircleRelayerMessages, CircleRelayerGovernance, Reentr
      * @dev The swap rate is governed by the `nativeSwapRate` state variable.
      * @param token Address of token being transferred.
      * @param toNativeAmount Quantity of tokens to be converted to native assets.
-     * @return nativeAmount The exchange rate between native assets and the
-     * `toNativeAmount` of transferred tokens.
+     * @return nativeAmount The amount of native tokens that a user receives.
      */
     function calculateNativeSwapAmountOut(
         address token,

--- a/evm/src/circle-relayer/CircleRelayerGetters.sol
+++ b/evm/src/circle-relayer/CircleRelayerGetters.sol
@@ -19,6 +19,13 @@ contract CircleRelayerGetters is CircleRelayerSetters {
         return IWormhole(_state.wormhole);
     }
 
+    /**
+     * @return paused If true, requests for token transfers will be blocked and no circle transfer VAAs will be generated.
+     */
+    function getPaused() public view returns (bool paused) {
+        paused = _state.paused;
+    }
+
     function chainId() public view returns (uint16) {
         return _state.chainId;
     }

--- a/evm/src/circle-relayer/CircleRelayerGovernance.sol
+++ b/evm/src/circle-relayer/CircleRelayerGovernance.sol
@@ -162,6 +162,19 @@ contract CircleRelayerGovernance is CircleRelayerGetters, ERC1967Upgrade {
         setMaxNativeSwapAmount(token, maxAmount);
     }
 
+    /**
+     * @notice Sets the pause state of the relayer. If paused, token transfer requests are blocked.
+     * In flight transfers, i.e. those that have a VAA emitted, can still be processed if paused.
+     * @param chainId_ Wormhole chain ID
+     * @param paused If true, requests for token transfers will be blocked and no circle transfer VAAs will be generated.
+     */
+    function setPauseForTransfers(
+        uint16 chainId_,
+        bool paused
+    ) public onlyOwner onlyCurrentChain(chainId_) {
+        setPaused(paused);
+    }
+
     modifier onlyOwner() {
         require(owner() == msg.sender, "caller not the owner");
         _;
@@ -169,6 +182,11 @@ contract CircleRelayerGovernance is CircleRelayerGetters, ERC1967Upgrade {
 
     modifier onlyCurrentChain(uint16 chainId_) {
         require(chainId() == chainId_, "wrong chain");
+        _;
+    }
+
+    modifier notPaused() {
+        require(!getPaused(), "relayer is paused");
         _;
     }
 }

--- a/evm/src/circle-relayer/CircleRelayerSetters.sol
+++ b/evm/src/circle-relayer/CircleRelayerSetters.sol
@@ -12,6 +12,10 @@ contract CircleRelayerSetters is CircleRelayerState {
         _state.pendingOwner = pendingOwner_;
     }
 
+    function setPaused(bool paused) internal {
+        _state.paused = paused;
+    }
+
     function setWormhole(address wormhole_) internal {
         _state.wormhole = payable(wormhole_);
     }

--- a/evm/src/circle-relayer/CircleRelayerState.sol
+++ b/evm/src/circle-relayer/CircleRelayerState.sol
@@ -46,9 +46,6 @@ contract CircleRelayerStorage {
 
         // Wormhole chain ID to registered contract address mapping
         mapping(uint16 => bytes32) registeredContracts;
-
-        // verified message hash to boolean
-        mapping(bytes32 => bool) consumedMessages;
     }
 }
 

--- a/evm/src/circle-relayer/CircleRelayerState.sol
+++ b/evm/src/circle-relayer/CircleRelayerState.sol
@@ -11,6 +11,9 @@ contract CircleRelayerStorage {
         // decimals of the native token on this chain
         uint8 nativeTokenDecimals;
 
+        // If true, token transfer requests are blocked.
+        bool paused;
+
         // owner of this contract
         address owner;
 

--- a/evm/src/interfaces/ICircleRelayer.sol
+++ b/evm/src/interfaces/ICircleRelayer.sol
@@ -51,6 +51,8 @@ interface ICircleRelayer {
 
     function updateMaxNativeSwapAmount(uint16 chainId_, address token, uint256 maxAmount) external;
 
+    function setPauseForTransfers(uint16 chainId_, bool paused) external;
+
     function owner() external view returns (address);
 
     function pendingOwner() external view returns (address);

--- a/evm/src/interfaces/IUSDC.sol
+++ b/evm/src/interfaces/IUSDC.sol
@@ -16,4 +16,5 @@ interface IUSDC {
     function allowance(address owner, address spender) external view returns (uint256);
     function approve(address spender, uint256 amount) external returns (bool);
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function decimals() external view returns (uint8);
 }


### PR DESCRIPTION
This adds the ability to pause transfer requests to phase out the contract when opportune.

Other changes:
- Adds swap event to inform relayers of the swapped amount.
- Replaced some low level static calls with plain function calls through `IERC20Metadata` and `IUSDC` interfaces since they are properly marked as `view`.
- Removes unnecessary qualifier in constructor.
- Fixes natspec documentation for return value in `calculateNativeSwapAmountOut`.